### PR TITLE
Fix scene load fail on missing asset

### DIFF
--- a/viewer/js_bindings.cpp
+++ b/viewer/js_bindings.cpp
@@ -1031,12 +1031,16 @@ JSValue JsLoadMesh(JSContext *ctx, JSValueConst, int argc, JSValueConst *argv) {
   if (!std::filesystem::exists(fsPath, ec) || ec) {
     const std::string msg = "loadMesh: file not found '" + resolvedPath + "' (expected in ~/Downloads/models)";
     PrintLoadMeshError(msg);
-    return JS_ThrowInternalError(ctx, "loadMesh: file not found '%s'", resolvedPath.c_str());
+    // Return an empty manifold so the scene can continue loading.
+    auto handle = std::make_shared<manifold::Manifold>();
+    return WrapManifold(ctx, std::move(handle));
   }
   if (!std::filesystem::is_regular_file(fsPath, ec) || ec) {
     const std::string msg = "loadMesh: not a regular file '" + resolvedPath + "'";
     PrintLoadMeshError(msg);
-    return JS_ThrowInternalError(ctx, "loadMesh: not a regular file '%s'", resolvedPath.c_str());
+    // Return an empty manifold so the scene can continue loading.
+    auto handle = std::make_shared<manifold::Manifold>();
+    return WrapManifold(ctx, std::move(handle));
   }
 
   bool forceCleanup = false;


### PR DESCRIPTION
Gracefully handles missing/broken assets in scene.js
Still provides errors in console

<img width="775" height="141" alt="image" src="https://github.com/user-attachments/assets/3c7f8355-9b34-4922-bb45-015879c4cb07" />

I don't have 'Downloads/models/seedespc3.stl' so the scene was not being loaded, with a message on top left saying 'no scene found'

This fixes the issue, and allows me to load everything but the broken asset. 